### PR TITLE
VESA driver integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ OBJ = $(GENDIR)/kernel.o\
 	$(GENDIR)/drivers/keyboard.o\
 	$(GENDIR)/drivers/mouse.o\
 	$(GENDIR)/drivers/fdc.o\
+	$(GENDIR)/drivers/vesa.o\
 	$(GENDIR)/fs/vfs.o\
 	$(GENDIR)/fs/fcntl.o\
 	$(GENDIR)/fs/initrd.o\
@@ -103,6 +104,7 @@ $(GENDIR)/misc/debug.o: src/misc/debug.c
 $(GENDIR)/drivers/keyboard.o: src/drivers/keyboard.c
 $(GENDIR)/drivers/mouse.o: src/drivers/mouse.c
 $(GENDIR)/drivers/fdc.o: src/drivers/fdc.c
+$(GENDIR)/drivers/vesa.o: src/drivers/vesa.c
 
 $(GENDIR)/system/gdt.o: src/system/gdt.c
 $(GENDIR)/system/idt.o: src/system/idt.c

--- a/src/drivers/vesa.c
+++ b/src/drivers/vesa.c
@@ -1,0 +1,80 @@
+/***************************************************************************
+ *            vesa.c
+ *
+ *  Fri Jan 6 07:47:55 2017
+ *  Copyright  2017  Davide Gessa (dakk)
+ *  Email : gessadavide@gmail.com
+ *  VESA driver
+ * ***************************************************************************/
+
+/*
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <drivers/vesa.h>
+#include <misc/support_defs.h>
+
+vesa_info_t *vci;
+vesa_mode_info_t *vmi;
+
+			
+vesa_mode_info_t *vesa_get_mode_info()
+{
+	return vmi;
+}
+
+
+void vesa_draw_pixel(uint32_t x, uint32_t y, uint32_t cl)
+{
+	register char *ptmp;
+	
+	if (x < 0 || x > vmi->width || y < 0 || y > vmi->height) return;
+	
+	x = (x * (vmi->bits_per_pixel >> 3));
+	y = (y * vmi->bytes_per_scan_line);
+	
+	char *asd = (char *)vmi->phys_base_ptr;
+	ptmp = &asd[x+y];
+	ptmp[0] = cl & 0xff;
+	ptmp[1] = (cl>>8) & 0xff;
+	ptmp[2] = (cl>>16) & 0xff;
+}
+
+
+
+uint32_t vesa_get_pixel(uint32_t x, uint32_t y)
+{
+	if (x < 0 || x > vmi->width || y < 0 || y > vmi->height) return 0;
+	
+	x = (x * (vmi->bits_per_pixel >> 3));
+	y = (y * vmi->bytes_per_scan_line);
+	
+	char *vmem = (char *) vmi->phys_base_ptr;
+    return (uint32_t) vmem [x+y];
+}
+
+
+uint32_t vesa_set_mode(uint32_t x, uint32_t y, uint32_t bit)
+{
+	return 0;
+}
+
+
+uint32_t vesa_init(void *vbe_control_info, void *vbe_mode_info)
+{
+	vci = (vesa_info_t *) vbe_control_info;
+	vmi = (vesa_mode_info_t *) vbe_mode_info;
+    return 0;
+}

--- a/src/include/drivers/vesa.h
+++ b/src/include/drivers/vesa.h
@@ -1,0 +1,103 @@
+/***************************************************************************
+ *            vesa.h
+ *
+ *  Fri Jan 6 07:47:55 2017
+ *  Copyright  2017  Davide Gessa (dakk)
+ *  Email : gessadavide@gmail.com
+ *  VESA driver
+ * ***************************************************************************/
+
+/*
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef _VESA_H_
+#define _VESA_H_
+
+#include <misc/support_defs.h>
+
+typedef struct
+{
+    char signature[4];
+    uint16_t version;
+    uint32_t oem_string_ptr;
+    uint32_t capabilities;
+    uint32_t video_mode_ptr;
+    uint16_t total_memory;
+	
+	uint32_t oem_software_rev;
+	char *oem_vendor_name;
+	char *oem_product_name;
+	char *oem_product_rev;
+} vesa_info_t;
+
+ 
+typedef struct
+{
+    uint16_t mode_attributes;
+    uint8_t wina_attributes;
+    uint8_t winb_attributes;
+    uint16_t win_granularity;
+    uint16_t win_size;
+    uint16_t wina_segment;
+    uint16_t winb_segment;
+    uint32_t win_pos_func_ptr;
+    uint16_t bytes_per_scan_line;
+    uint16_t width;
+    uint16_t height;
+    uint8_t char_width;
+    uint8_t char_height;
+    uint8_t num_planes;
+    uint8_t bits_per_pixel;
+    uint8_t num_banks;
+    uint8_t memory_model_type;
+    uint8_t bank_size;
+    uint8_t num_image_pages;
+    uint8_t reserved1;
+    uint8_t red_mask_size;
+    uint8_t red_field_position;
+    uint8_t green_mask_size;
+    uint8_t green_field_position;
+    uint8_t blue_mask_size;
+    uint8_t blue_field_position;
+    uint8_t reserved_mask_size;
+    uint8_t reserved_mask_position;
+    uint8_t direct_color_mode_info;
+    uint32_t phys_base_ptr;
+    uint32_t offscreen_mem_ptr;
+    uint16_t offscreen_mem_size;
+    uint16_t lin_bytes_per_scan_line;
+    uint8_t bnk_num_image_pages;
+    uint8_t lin_num_image_pages;
+    uint8_t lin_red_mask_size;
+    uint8_t lin_red_field_position;
+    uint8_t lin_green_mask_size;
+    uint8_t lin_green_field_position;
+    uint8_t lin_blue_mask_size;
+    uint8_t lin_blue_field_position;
+    uint8_t lin_rsvd_mask_size;
+    uint8_t lin_rsvd_field_position;
+    uint32_t max_pixel_clock;
+    uint8_t reserved4[190];
+} vesa_mode_info_t;
+
+
+vesa_mode_info_t *vesa_get_mode_info();
+uint32_t vesa_init (void *, void *);
+void vesa_draw_pixel(uint32_t, uint32_t, uint32_t);
+uint32_t vesa_get_pixel(uint32_t, uint32_t);
+uint32_t vesa_set_mode(uint32_t, uint32_t, uint32_t);
+
+#endif


### PR DESCRIPTION
Integration of VESA driver from https://github.com/dakk/spiderpig-os to DreamOS.

It needs multiboot structure parsing to get vbe memory addresses and be able to render pixels.