### PR TITLE
Gdt code checking

### DIFF
--- a/src/include/system/gdt.h
+++ b/src/include/system/gdt.h
@@ -25,14 +25,15 @@
 #define _GDT_H
 #include <stddef.h>
 
-#define GDT_SIZE 8192
+#define GDT_SIZE 10
 
 //For opt_2 argument
-#define PRESENT 0x80
+#define GRANULARITY 0x80
+#define SZBITS 0x40
 //#define GRANULARITY 0x40
 
 //For opt_1 argument
-#define GRANULARITY 0x80
+#define PRESENT 0x80
 #define NOT_PRESENT 0x00
 #define KERNEL 0x00
 #define RING1 0x01
@@ -61,11 +62,11 @@ typedef struct gdt_desc {
 } __attribute__((packed)) GDT_Descriptor;
 
 /*!  \struct gdt_r
-     \brief Struttura dati che serve a caricare la IDT nel IDTR
+     \brief Struttura dati che serve a caricare la GDT nel GDTR
  */
 typedef struct gdt_r {
 	unsigned short int gdt_limit;/**< la dimensione della GDT (in numero di entry)*/
-	unsigned int gdt_base;/**< l'indirizzo iniziale della IDT*/
+	unsigned int gdt_base;/**< l'indirizzo iniziale della GDT*/
 } __attribute__((packed)) GDT_Register;
 
 void set_gdtr(GDT_Descriptor *, unsigned short int, int, int);

--- a/src/system/gdt.c
+++ b/src/system/gdt.c
@@ -47,8 +47,8 @@ void init_gdt(){
 	 *il descrittore nullo deve stare nella posizione 0
 	 */
 	add_GDTseg(0,0,0,0,0);
-	add_GDTseg(1,0x00000000,0x000FFFFF, PRESENT|KERNEL|CODE|0x0A,GRANULARITY);
-	add_GDTseg(2,0x00000000,0x000FFFFF, PRESENT|KERNEL|DATA|0x02,GRANULARITY);
+	add_GDTseg(1,0x00000000,0x000FFFFF, PRESENT|KERNEL|CODE|0x0A,GRANULARITY|SZBITS);
+	add_GDTseg(2,0x00000000,0x000FFFFF, PRESENT|KERNEL|DATA|0x02,GRANULARITY|SZBITS);
 	set_gdtr(Gdt_Table, 0xFFFF, 1, 2);	
 }
 /**
@@ -64,14 +64,16 @@ void add_GDTseg(int pos,unsigned int base, unsigned int limit, unsigned char opt
 	unsigned int tmpbase, tmplimit;
 	tmpbase = base;
 	tmplimit = limit;
+    //First 32bit part
 	Gdt_Table[pos].segment_limit_low = limit & 0xFFFF;
-	Gdt_Table[pos].segment_base_low = base & 0xFFFF; //Primi 32byte
+	Gdt_Table[pos].segment_base_low = base & 0xFFFF;
+    //Last 32bit part
 	tmpbase = base >>16;
 	Gdt_Table[pos].base_mid = tmpbase & 0xFF;
 	Gdt_Table[pos].options_1= opt1;
 	tmplimit= limit >> 16;
 	tmplimit &=0xf;
-	Gdt_Table[pos].options_2= GRANULARITY|0x40|tmplimit;
+	Gdt_Table[pos].options_2= opt2|tmplimit;
 	tmpbase = base >>24;
 	Gdt_Table[pos].base_high = tmpbase & 0xFF;
 }


### PR DESCRIPTION
- Improved readability of some comment in gdt.c / gdt.h
- Set GDT_SIZE max entries to 10. Too many 8192
- Added SZBITS macro instead of hardcoding it in the function
- opt2 parameter is now used, before GRANULARITY bit was manually set