### PR TITLE
Wrong size kmalloc allocation

### DIFF
--- a/src/shell/commands.c
+++ b/src/shell/commands.c
@@ -119,7 +119,7 @@ void poweroff()
 void uname_cmd()
 {
   struct utsname *infos;
-  infos = kmalloc(sizeof(struct utsname *));
+  infos = kmalloc(sizeof(struct utsname));
   uname(infos);
   if (!(strcmp(argv[1], "-a")) || !(strcmp(argv[1], "--all")))
     printf("%s %s.%s%s Hash: %s #1 CEST 2013 %s\n", infos->sysname, infos->version, infos->release, EXTRAVERSION,REV_NUM, cpu_vendor);


### PR DESCRIPTION
- "uname" allocated only 4 bytes space (one pointer) instead of 5 pointers space (all 5 static arrays inside the struct)